### PR TITLE
Add weight and food tracking with menu navigation

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 
 const authRoutes = require('./routes/auth');
 const weightRoutes = require('./routes/weights');
+const foodRoutes = require('./routes/foods');
 require('./db');
 
 const app = express();
@@ -12,6 +13,7 @@ app.use(express.json());
 
 app.use('/api/auth', authRoutes);
 app.use('/api/weights', weightRoutes);
+app.use('/api/foods', foodRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const weightRoutes = require('./routes/weights');
 const foodRoutes = require('./routes/foods');
+const foodItemRoutes = require('./routes/foodItems');
 require('./db');
 
 const app = express();
@@ -14,6 +15,7 @@ app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/weights', weightRoutes);
 app.use('/api/foods', foodRoutes);
+app.use('/api/food-items', foodItemRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/src/controllers/foodItemsController.js
+++ b/backend/src/controllers/foodItemsController.js
@@ -1,0 +1,30 @@
+const db = require('../db');
+
+exports.list = async (req, res) => {
+  const q = req.query.q || '';
+  try {
+    const [rows] = await db.execute(
+      'SELECT id, name, serving_size, serving_unit, calories FROM food_items WHERE user_id = ? AND name LIKE ? ORDER BY name ASC',
+      [req.user.id, `%${q}%`]
+    );
+    res.json(rows);
+  } catch (err) {
+    res.sendStatus(500);
+  }
+};
+
+exports.create = async (req, res) => {
+  const { name, serving_size, serving_unit, calories, fat, saturated_fat, trans_fat, cholesterol, sodium, carbohydrates, fiber, sugar, protein } = req.body;
+  if (!name || !serving_size || !serving_unit || calories == null) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+  try {
+    const [result] = await db.execute(
+      'INSERT INTO food_items (user_id, name, serving_size, serving_unit, calories, fat, saturated_fat, trans_fat, cholesterol, sodium, carbohydrates, fiber, sugar, protein) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [req.user.id, name, serving_size, serving_unit, calories, fat || 0, saturated_fat || 0, trans_fat || 0, cholesterol || 0, sodium || 0, carbohydrates || 0, fiber || 0, sugar || 0, protein || 0]
+    );
+    res.status(201).json({ id: result.insertId, name });
+  } catch (err) {
+    res.sendStatus(500);
+  }
+};

--- a/backend/src/controllers/foodsController.js
+++ b/backend/src/controllers/foodsController.js
@@ -1,0 +1,75 @@
+const db = require('../db');
+
+exports.list = async (req, res) => {
+  try {
+    const [rows] = await db.execute(
+      'SELECT id, name, calories, consumed_at FROM foods WHERE user_id = ? ORDER BY consumed_at DESC',
+      [req.user.id]
+    );
+    res.json(rows);
+  } catch (err) {
+    res.sendStatus(500);
+  }
+};
+
+exports.create = async (req, res) => {
+  const { name, calories } = req.body;
+  if (!name || !calories) {
+    return res.status(400).json({ error: 'Name and calories required' });
+  }
+  const date = new Date().toISOString().split('T')[0];
+  try {
+    const [result] = await db.execute(
+      'INSERT INTO foods (user_id, name, calories, consumed_at) VALUES (?, ?, ?, ?)',
+      [req.user.id, name, calories, date]
+    );
+    res.status(201).json({ id: result.insertId, name, calories, consumed_at: date });
+  } catch (err) {
+    res.sendStatus(500);
+  }
+};
+
+exports.update = async (req, res) => {
+  const { name, calories } = req.body;
+  if (!name && !calories) {
+    return res.status(400).json({ error: 'Nothing to update' });
+  }
+  const fields = [];
+  const params = [];
+  if (name) {
+    fields.push('name = ?');
+    params.push(name);
+  }
+  if (calories) {
+    fields.push('calories = ?');
+    params.push(calories);
+  }
+  params.push(req.params.id, req.user.id);
+  try {
+    const [result] = await db.execute(
+      `UPDATE foods SET ${fields.join(', ')} WHERE id = ? AND user_id = ?`,
+      params
+    );
+    if (result.affectedRows === 0) {
+      return res.sendStatus(404);
+    }
+    res.sendStatus(204);
+  } catch (err) {
+    res.sendStatus(500);
+  }
+};
+
+exports.remove = async (req, res) => {
+  try {
+    const [result] = await db.execute(
+      'DELETE FROM foods WHERE id = ? AND user_id = ?',
+      [req.params.id, req.user.id]
+    );
+    if (result.affectedRows === 0) {
+      return res.sendStatus(404);
+    }
+    res.sendStatus(204);
+  } catch (err) {
+    res.sendStatus(500);
+  }
+};

--- a/backend/src/controllers/foodsController.js
+++ b/backend/src/controllers/foodsController.js
@@ -3,7 +3,7 @@ const db = require('../db');
 exports.list = async (req, res) => {
   try {
     const [rows] = await db.execute(
-      'SELECT id, name, calories, consumed_at FROM foods WHERE user_id = ? ORDER BY consumed_at DESC',
+      'SELECT id, name, calories, servings, consumed_at FROM foods WHERE user_id = ? ORDER BY consumed_at DESC',
       [req.user.id]
     );
     res.json(rows);
@@ -13,25 +13,41 @@ exports.list = async (req, res) => {
 };
 
 exports.create = async (req, res) => {
-  const { name, calories } = req.body;
-  if (!name || !calories) {
+  const { food_item_id, servings = 1 } = req.body;
+  let { name, calories } = req.body;
+  if (food_item_id) {
+    try {
+      const [rows] = await db.execute(
+        'SELECT name, calories FROM food_items WHERE id = ? AND user_id = ?',
+        [food_item_id, req.user.id]
+      );
+      if (rows.length === 0) {
+        return res.status(400).json({ error: 'Invalid food item' });
+      }
+      name = rows[0].name;
+      calories = rows[0].calories * servings;
+    } catch (err) {
+      return res.sendStatus(500);
+    }
+  }
+  if (!name || calories == null) {
     return res.status(400).json({ error: 'Name and calories required' });
   }
   const date = new Date().toISOString().split('T')[0];
   try {
     const [result] = await db.execute(
-      'INSERT INTO foods (user_id, name, calories, consumed_at) VALUES (?, ?, ?, ?)',
-      [req.user.id, name, calories, date]
+      'INSERT INTO foods (user_id, name, calories, consumed_at, food_item_id, servings) VALUES (?, ?, ?, ?, ?, ?)',
+      [req.user.id, name, calories, date, food_item_id || null, servings]
     );
-    res.status(201).json({ id: result.insertId, name, calories, consumed_at: date });
+    res.status(201).json({ id: result.insertId, name, calories, consumed_at: date, food_item_id, servings });
   } catch (err) {
     res.sendStatus(500);
   }
 };
 
 exports.update = async (req, res) => {
-  const { name, calories } = req.body;
-  if (!name && !calories) {
+  const { name, calories, servings } = req.body;
+  if (!name && !calories && !servings) {
     return res.status(400).json({ error: 'Nothing to update' });
   }
   const fields = [];
@@ -43,6 +59,10 @@ exports.update = async (req, res) => {
   if (calories) {
     fields.push('calories = ?');
     params.push(calories);
+  }
+  if (servings) {
+    fields.push('servings = ?');
+    params.push(servings);
   }
   params.push(req.params.id, req.user.id);
   try {

--- a/backend/src/controllers/weightsController.js
+++ b/backend/src/controllers/weightsController.js
@@ -1,17 +1,64 @@
 const db = require('../db');
 
 exports.list = async (req, res) => {
-  res.sendStatus(501);
+  try {
+    const [rows] = await db.execute(
+      'SELECT id, value AS weight, recorded_at AS entry_date FROM weights WHERE user_id = ? ORDER BY recorded_at DESC',
+      [req.user.id]
+    );
+    res.json(rows);
+  } catch (err) {
+    res.sendStatus(500);
+  }
 };
 
 exports.create = async (req, res) => {
-  res.sendStatus(501);
+  const { weight } = req.body;
+  if (!weight) {
+    return res.status(400).json({ error: 'Weight required' });
+  }
+  const date = new Date().toISOString().split('T')[0];
+  try {
+    const [result] = await db.execute(
+      'INSERT INTO weights (user_id, value, recorded_at) VALUES (?, ?, ?)',
+      [req.user.id, weight, date]
+    );
+    res.status(201).json({ id: result.insertId, weight, entry_date: date });
+  } catch (err) {
+    res.sendStatus(500);
+  }
 };
 
 exports.update = async (req, res) => {
-  res.sendStatus(501);
+  const { weight } = req.body;
+  if (!weight) {
+    return res.status(400).json({ error: 'Weight required' });
+  }
+  try {
+    const [result] = await db.execute(
+      'UPDATE weights SET value = ? WHERE id = ? AND user_id = ?',
+      [weight, req.params.id, req.user.id]
+    );
+    if (result.affectedRows === 0) {
+      return res.sendStatus(404);
+    }
+    res.sendStatus(204);
+  } catch (err) {
+    res.sendStatus(500);
+  }
 };
 
 exports.remove = async (req, res) => {
-  res.sendStatus(501);
+  try {
+    const [result] = await db.execute(
+      'DELETE FROM weights WHERE id = ? AND user_id = ?',
+      [req.params.id, req.user.id]
+    );
+    if (result.affectedRows === 0) {
+      return res.sendStatus(404);
+    }
+    res.sendStatus(204);
+  } catch (err) {
+    res.sendStatus(500);
+  }
 };

--- a/backend/src/routes/foodItems.js
+++ b/backend/src/routes/foodItems.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const foodItemsController = require('../controllers/foodItemsController');
+const { verifyToken } = require('../middleware/auth');
+
+router.get('/', verifyToken, foodItemsController.list);
+router.post('/', verifyToken, foodItemsController.create);
+
+module.exports = router;

--- a/backend/src/routes/foods.js
+++ b/backend/src/routes/foods.js
@@ -1,0 +1,10 @@
+const router = require('express').Router();
+const foodsController = require('../controllers/foodsController');
+const { verifyToken } = require('../middleware/auth');
+
+router.get('/', verifyToken, foodsController.list);
+router.post('/', verifyToken, foodsController.create);
+router.put('/:id', verifyToken, foodsController.update);
+router.delete('/:id', verifyToken, foodsController.remove);
+
+module.exports = router;

--- a/database/scripts/food_items.sql
+++ b/database/scripts/food_items.sql
@@ -1,0 +1,20 @@
+-- Food items table
+CREATE TABLE IF NOT EXISTS food_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  serving_size DECIMAL(10,2) NOT NULL,
+  serving_unit VARCHAR(20) NOT NULL,
+  calories DECIMAL(10,2) NOT NULL,
+  fat DECIMAL(10,2) DEFAULT 0,
+  saturated_fat DECIMAL(10,2) DEFAULT 0,
+  trans_fat DECIMAL(10,2) DEFAULT 0,
+  cholesterol DECIMAL(10,2) DEFAULT 0,
+  sodium DECIMAL(10,2) DEFAULT 0,
+  carbohydrates DECIMAL(10,2) DEFAULT 0,
+  fiber DECIMAL(10,2) DEFAULT 0,
+  sugar DECIMAL(10,2) DEFAULT 0,
+  protein DECIMAL(10,2) DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/database/scripts/foods.sql
+++ b/database/scripts/foods.sql
@@ -1,0 +1,10 @@
+-- Foods table
+CREATE TABLE IF NOT EXISTS foods (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  calories INT NOT NULL,
+  consumed_at DATE NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/database/scripts/foods_add_fields.sql
+++ b/database/scripts/foods_add_fields.sql
@@ -1,0 +1,5 @@
+-- Add item reference and servings to foods
+ALTER TABLE foods
+  ADD COLUMN food_item_id INT NULL,
+  ADD COLUMN servings DECIMAL(10,2) DEFAULT 1,
+  ADD FOREIGN KEY (food_item_id) REFERENCES food_items(id) ON DELETE SET NULL;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,3 +1,9 @@
 <template>
-  <router-view />
+  <div>
+    <nav>
+      <router-link to="/dashboard">Weights</router-link>
+      <router-link to="/foods">Foods</router-link>
+    </nav>
+    <router-view />
+  </div>
 </template>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,6 +3,7 @@
     <nav>
       <router-link to="/dashboard">Weights</router-link>
       <router-link to="/foods">Foods</router-link>
+      <router-link to="/food-items">Food Items</router-link>
     </nav>
     <router-view />
   </div>

--- a/frontend/src/components/FoodForm.vue
+++ b/frontend/src/components/FoodForm.vue
@@ -1,0 +1,21 @@
+<script setup>
+import { ref } from 'vue';
+import api from '../api';
+const name = ref('');
+const calories = ref('');
+const emit = defineEmits(['saved']);
+async function submit() {
+  await api.post('/foods', { name: name.value, calories: calories.value });
+  name.value = '';
+  calories.value = '';
+  emit('saved');
+}
+</script>
+
+<template>
+  <form @submit.prevent="submit">
+    <input v-model="name" placeholder="Food" />
+    <input v-model="calories" type="number" placeholder="Calories" />
+    <button type="submit">Add</button>
+  </form>
+</template>

--- a/frontend/src/components/FoodForm.vue
+++ b/frontend/src/components/FoodForm.vue
@@ -40,7 +40,7 @@ async function submit() {
       </li>
     </ul>
     <div v-if="selected">
-      <input v-model="servings" type="number" step="0.1" min="0" />
+      <input v-model="servings" type="number" step="0.01" min="0" />
       <button type="submit">Add</button>
     </div>
   </form>

--- a/frontend/src/components/FoodForm.vue
+++ b/frontend/src/components/FoodForm.vue
@@ -1,21 +1,47 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import api from '../api';
-const name = ref('');
-const calories = ref('');
+import { useFoodItemStore } from '../store/foodItems';
+const query = ref('');
+const selected = ref(null);
+const servings = ref(1);
+const itemStore = useFoodItemStore();
 const emit = defineEmits(['saved']);
+watch(query, async q => {
+  if (q.length > 1) {
+    await itemStore.search(q);
+  } else {
+    itemStore.items = [];
+  }
+});
+function selectItem(item) {
+  selected.value = item;
+  query.value = item.name;
+  itemStore.items = [];
+}
 async function submit() {
-  await api.post('/foods', { name: name.value, calories: calories.value });
-  name.value = '';
-  calories.value = '';
+  if (!selected.value) {
+    return;
+  }
+  await api.post('/foods', { food_item_id: selected.value.id, servings: servings.value });
+  query.value = '';
+  selected.value = null;
+  servings.value = 1;
   emit('saved');
 }
 </script>
 
 <template>
   <form @submit.prevent="submit">
-    <input v-model="name" placeholder="Food" />
-    <input v-model="calories" type="number" placeholder="Calories" />
-    <button type="submit">Add</button>
+    <input v-model="query" placeholder="Search food" />
+    <ul v-if="itemStore.items.length">
+      <li v-for="item in itemStore.items" :key="item.id" @click="selectItem(item)">
+        {{ item.name }} ({{ item.calories }} cal/{{ item.serving_size }}{{ item.serving_unit }})
+      </li>
+    </ul>
+    <div v-if="selected">
+      <input v-model="servings" type="number" step="0.1" min="0" />
+      <button type="submit">Add</button>
+    </div>
   </form>
 </template>

--- a/frontend/src/components/FoodItemForm.vue
+++ b/frontend/src/components/FoodItemForm.vue
@@ -26,18 +26,18 @@ async function submit() {
 <template>
   <form @submit.prevent="submit">
     <input v-model="form.name" placeholder="Name" />
-    <input v-model="form.serving_size" type="number" placeholder="Serving Size" />
+    <input v-model="form.serving_size" type="number" step="0.01" placeholder="Serving Size" />
     <input v-model="form.serving_unit" placeholder="Unit" />
-    <input v-model="form.calories" type="number" placeholder="Calories" />
-    <input v-model="form.fat" type="number" placeholder="Fat" />
-    <input v-model="form.saturated_fat" type="number" placeholder="Saturated Fat" />
-    <input v-model="form.trans_fat" type="number" placeholder="Trans Fat" />
-    <input v-model="form.cholesterol" type="number" placeholder="Cholesterol" />
-    <input v-model="form.sodium" type="number" placeholder="Sodium" />
-    <input v-model="form.carbohydrates" type="number" placeholder="Carbs" />
-    <input v-model="form.fiber" type="number" placeholder="Fiber" />
-    <input v-model="form.sugar" type="number" placeholder="Sugar" />
-    <input v-model="form.protein" type="number" placeholder="Protein" />
+    <input v-model="form.calories" type="number" step="0.01" placeholder="Calories" />
+    <input v-model="form.fat" type="number" step="0.01" placeholder="Fat" />
+    <input v-model="form.saturated_fat" type="number" step="0.01" placeholder="Saturated Fat" />
+    <input v-model="form.trans_fat" type="number" step="0.01" placeholder="Trans Fat" />
+    <input v-model="form.cholesterol" type="number" step="0.01" placeholder="Cholesterol" />
+    <input v-model="form.sodium" type="number" step="0.01" placeholder="Sodium" />
+    <input v-model="form.carbohydrates" type="number" step="0.01" placeholder="Carbs" />
+    <input v-model="form.fiber" type="number" step="0.01" placeholder="Fiber" />
+    <input v-model="form.sugar" type="number" step="0.01" placeholder="Sugar" />
+    <input v-model="form.protein" type="number" step="0.01" placeholder="Protein" />
     <button type="submit">Save</button>
   </form>
 </template>

--- a/frontend/src/components/FoodItemForm.vue
+++ b/frontend/src/components/FoodItemForm.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { ref } from 'vue';
+import { useFoodItemStore } from '../store/foodItems';
+const store = useFoodItemStore();
+const form = ref({
+  name: '',
+  serving_size: '',
+  serving_unit: '',
+  calories: '',
+  fat: '',
+  saturated_fat: '',
+  trans_fat: '',
+  cholesterol: '',
+  sodium: '',
+  carbohydrates: '',
+  fiber: '',
+  sugar: '',
+  protein: ''
+});
+async function submit() {
+  await store.create(form.value);
+  Object.keys(form.value).forEach(k => (form.value[k] = ''));
+}
+</script>
+
+<template>
+  <form @submit.prevent="submit">
+    <input v-model="form.name" placeholder="Name" />
+    <input v-model="form.serving_size" type="number" placeholder="Serving Size" />
+    <input v-model="form.serving_unit" placeholder="Unit" />
+    <input v-model="form.calories" type="number" placeholder="Calories" />
+    <input v-model="form.fat" type="number" placeholder="Fat" />
+    <input v-model="form.saturated_fat" type="number" placeholder="Saturated Fat" />
+    <input v-model="form.trans_fat" type="number" placeholder="Trans Fat" />
+    <input v-model="form.cholesterol" type="number" placeholder="Cholesterol" />
+    <input v-model="form.sodium" type="number" placeholder="Sodium" />
+    <input v-model="form.carbohydrates" type="number" placeholder="Carbs" />
+    <input v-model="form.fiber" type="number" placeholder="Fiber" />
+    <input v-model="form.sugar" type="number" placeholder="Sugar" />
+    <input v-model="form.protein" type="number" placeholder="Protein" />
+    <button type="submit">Save</button>
+  </form>
+</template>

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { onMounted } from 'vue';
+import { useFoodStore } from '../store/foods';
+const store = useFoodStore();
+onMounted(() => store.fetchFoods());
+</script>
+
+<template>
+  <ul>
+    <li v-for="item in store.foods" :key="item.id">
+      {{ item.consumed_at }} - {{ item.name }} ({{ item.calories }} cal)
+    </li>
+  </ul>
+</template>

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -8,7 +8,7 @@ onMounted(() => store.fetchFoods());
 <template>
   <ul>
     <li v-for="item in store.foods" :key="item.id">
-      {{ item.consumed_at }} - {{ item.name }} ({{ item.calories }} cal)
+      {{ item.consumed_at }} - {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
     </li>
   </ul>
 </template>

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -3,12 +3,13 @@ import { onMounted } from 'vue';
 import { useFoodStore } from '../store/foods';
 const store = useFoodStore();
 onMounted(() => store.fetchFoods());
+const formatDate = d => new Date(d).toLocaleDateString();
 </script>
 
 <template>
   <ul>
     <li v-for="item in store.foods" :key="item.id">
-      {{ item.consumed_at }} - {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
+      {{ formatDate(item.consumed_at) }} - {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
     </li>
   </ul>
 </template>

--- a/frontend/src/components/WeightForm.vue
+++ b/frontend/src/components/WeightForm.vue
@@ -14,7 +14,7 @@ async function submit() {
 
 <template>
   <form @submit.prevent="submit">
-    <input v-model="weight" placeholder="Weight" />
+    <input v-model="weight" type="number" step="0.1" placeholder="Weight" />
     <input v-model="note" placeholder="Note" />
     <button type="submit">Add</button>
   </form>

--- a/frontend/src/components/WeightList.vue
+++ b/frontend/src/components/WeightList.vue
@@ -3,12 +3,13 @@ import { onMounted } from 'vue';
 import { useWeightStore } from '../store/weights';
 const store = useWeightStore();
 onMounted(() => store.fetchWeights());
+const formatDate = d => new Date(d).toLocaleDateString();
 </script>
 
 <template>
   <ul>
     <li v-for="entry in store.weights" :key="entry.id">
-      {{ entry.entry_date }} - {{ entry.weight }} kg
+      {{ formatDate(entry.entry_date) }} - {{ entry.weight }} kg
     </li>
   </ul>
 </template>

--- a/frontend/src/pages/FoodItems.vue
+++ b/frontend/src/pages/FoodItems.vue
@@ -1,0 +1,9 @@
+<script setup>
+import FoodItemForm from '../components/FoodItemForm.vue';
+</script>
+
+<template>
+  <div>
+    <FoodItemForm />
+  </div>
+</template>

--- a/frontend/src/pages/Foods.vue
+++ b/frontend/src/pages/Foods.vue
@@ -1,0 +1,16 @@
+<script setup>
+import FoodForm from '../components/FoodForm.vue';
+import FoodList from '../components/FoodList.vue';
+import { useFoodStore } from '../store/foods';
+const store = useFoodStore();
+function refresh() {
+  store.fetchFoods();
+}
+</script>
+
+<template>
+  <div>
+    <FoodForm @saved="refresh" />
+    <FoodList />
+  </div>
+</template>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,12 +2,14 @@ import { createRouter, createWebHistory } from 'vue-router';
 import Login from '../components/Login.vue';
 import Register from '../components/Register.vue';
 import Dashboard from '../pages/Dashboard.vue';
+import Foods from '../pages/Foods.vue';
 
 const routes = [
   { path: '/', redirect: '/login' },
   { path: '/login', component: Login },
   { path: '/register', component: Register },
-  { path: '/dashboard', component: Dashboard, meta: { requiresAuth: true } }
+  { path: '/dashboard', component: Dashboard, meta: { requiresAuth: true } },
+  { path: '/foods', component: Foods, meta: { requiresAuth: true } }
 ];
 
 const router = createRouter({

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,13 +3,15 @@ import Login from '../components/Login.vue';
 import Register from '../components/Register.vue';
 import Dashboard from '../pages/Dashboard.vue';
 import Foods from '../pages/Foods.vue';
+import FoodItems from '../pages/FoodItems.vue';
 
 const routes = [
   { path: '/', redirect: '/login' },
   { path: '/login', component: Login },
   { path: '/register', component: Register },
   { path: '/dashboard', component: Dashboard, meta: { requiresAuth: true } },
-  { path: '/foods', component: Foods, meta: { requiresAuth: true } }
+  { path: '/foods', component: Foods, meta: { requiresAuth: true } },
+  { path: '/food-items', component: FoodItems, meta: { requiresAuth: true } }
 ];
 
 const router = createRouter({

--- a/frontend/src/store/foodItems.js
+++ b/frontend/src/store/foodItems.js
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia';
+import api from '../api';
+
+export const useFoodItemStore = defineStore('foodItems', {
+  state: () => ({ items: [] }),
+  actions: {
+    async search(q) {
+      const res = await api.get('/food-items', { params: { q } });
+      this.items = res.data;
+    },
+    async create(data) {
+      await api.post('/food-items', data);
+    }
+  }
+});

--- a/frontend/src/store/foods.js
+++ b/frontend/src/store/foods.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia';
+import api from '../api';
+
+export const useFoodStore = defineStore('foods', {
+  state: () => ({ foods: [] }),
+  actions: {
+    async fetchFoods() {
+      const res = await api.get('/foods');
+      this.foods = res.data;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- implement CRUD operations for user weight entries
- add food tracking API, database table, and frontend components
- introduce simple navigation menu linking weight and food pages

## Testing
- `npm test` (backend)
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68ae4bf4e838832693baf1baccb65136