### PR TITLE
Add user unit preference

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -4,16 +4,27 @@ const jwt = require('jsonwebtoken');
 const { logError } = require('../logger');
 
 exports.register = async (req, res) => {
-  const { username, password, height_in, is_male, calories_to_cut = 0, role = 'user' } = req.body;
+  const {
+    username,
+    password,
+    height_in,
+    is_male,
+    calories_to_cut = 0,
+    role = 'user',
+    units = 'scientific'
+  } = req.body;
   if (!username || !password || height_in == null || is_male == null) {
     return res.status(400).json({ error: 'Username, password, height, and gender required' });
+  }
+  if (units !== 'imperial' && units !== 'scientific') {
+    return res.status(400).json({ error: 'Invalid units' });
   }
   try {
     const passwordHash = await bcrypt.hash(password, 10);
     const roleValue = role === 'admin' ? 'admin' : 'user';
     const [result] = await db.execute(
-      'INSERT INTO users (username, password_hash, height_in, is_male, calories_to_cut, role) VALUES (?, ?, ?, ?, ?, ?)',
-      [username, passwordHash, height_in, is_male, calories_to_cut, roleValue]
+      'INSERT INTO users (username, password_hash, height_in, is_male, calories_to_cut, role, units) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [username, passwordHash, height_in, is_male, calories_to_cut, roleValue, units]
     );
     res.status(201).json({ id: result.insertId, username });
   } catch (err) {

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -4,7 +4,7 @@ const { logError } = require('../logger');
 exports.get = async (req, res) => {
   try {
     const [rows] = await db.execute(
-      'SELECT username, height_in, is_male, calories_to_cut, theme FROM users WHERE id = ?',
+      'SELECT username, height_in, is_male, calories_to_cut, theme, units FROM users WHERE id = ?',
       [req.user.id]
     );
     if (rows.length === 0) {
@@ -18,8 +18,14 @@ exports.get = async (req, res) => {
 };
 
 exports.update = async (req, res) => {
-  const { height_in, is_male, calories_to_cut, theme } = req.body;
-  if (height_in == null && is_male == null && calories_to_cut == null && theme == null) {
+  const { height_in, is_male, calories_to_cut, theme, units } = req.body;
+  if (
+    height_in == null &&
+    is_male == null &&
+    calories_to_cut == null &&
+    theme == null &&
+    units == null
+  ) {
     return res.status(400).json({ error: 'Nothing to update' });
   }
   const fields = [];
@@ -42,6 +48,13 @@ exports.update = async (req, res) => {
     }
     fields.push('theme = ?');
     params.push(theme);
+  }
+  if (units != null) {
+    if (units !== 'imperial' && units !== 'scientific') {
+      return res.status(400).json({ error: 'Invalid units' });
+    }
+    fields.push('units = ?');
+    params.push(units);
   }
   params.push(req.user.id);
   try {

--- a/database/scripts/schema.sql
+++ b/database/scripts/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS users (
   calories_to_cut INT NOT NULL DEFAULT 0,
   role VARCHAR(10) NOT NULL DEFAULT 'user',
   theme VARCHAR(5) NOT NULL DEFAULT 'light',
+  units VARCHAR(10) NOT NULL DEFAULT 'scientific',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/database/scripts/users_add_units.sql
+++ b/database/scripts/users_add_units.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN units VARCHAR(10) NOT NULL DEFAULT 'scientific';

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import api from './api';
+import { useUserStore } from './store/user';
 
 const token = ref(localStorage.getItem('token'));
 const router = useRouter();
+const userStore = useUserStore();
 
 window.addEventListener('token-changed', () => {
   token.value = localStorage.getItem('token');
@@ -15,7 +16,8 @@ watch(
   async (newToken) => {
     if (newToken) {
       try {
-        const { data } = await api.get('/user');
+        await userStore.fetch();
+        const data = userStore.info;
         document.body.classList.remove('light', 'dark');
         document.body.classList.add(data.theme || 'light');
         localStorage.setItem('theme', data.theme || 'light');

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -25,10 +25,14 @@ function remove(id) {
 
 <template>
   <ul>
-    <li v-for="item in store.foods" :key="item.id">
-      {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
-      <button @click="edit(item)">Edit</button>
-      <button @click="remove(item.id)">Delete</button>
+    <li v-for="item in store.foods" :key="item.id" class="list-item">
+      <span>
+        {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
+      </span>
+      <span class="actions">
+        <button @click="edit(item)">Edit</button>
+        <button @click="remove(item.id)">Delete</button>
+      </span>
     </li>
   </ul>
 </template>

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -39,9 +39,22 @@ function remove(id) {
   <Modal v-if="editing" @close="cancelEdit">
     <form @submit.prevent="saveEdit">
       <h3>Edit Food</h3>
-      <input v-model="form.name" placeholder="Name" />
-      <input type="number" v-model.number="form.calories" placeholder="Calories" />
-      <input type="number" v-model.number="form.servings" placeholder="Servings" />
+      <label for="edit-name">Name</label>
+      <input id="edit-name" v-model="form.name" placeholder="Name" />
+      <label for="edit-calories">Calories</label>
+      <input
+        id="edit-calories"
+        type="number"
+        v-model.number="form.calories"
+        placeholder="Calories"
+      />
+      <label for="edit-servings">Servings</label>
+      <input
+        id="edit-servings"
+        type="number"
+        v-model.number="form.servings"
+        placeholder="Servings"
+      />
       <div class="actions">
         <button type="submit">Save</button>
         <button type="button" @click="cancelEdit">Cancel</button>

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -1,12 +1,34 @@
 <script setup>
 import { useFoodStore } from '../store/foods';
 const store = useFoodStore();
+
+function edit(item) {
+  const name = prompt('Name', item.name);
+  if (name === null) return;
+  const caloriesInput = prompt('Calories', item.calories);
+  if (caloriesInput === null) return;
+  const servingsInput = prompt('Servings', item.servings);
+  if (servingsInput === null) return;
+  store.updateFood(item.id, {
+    name,
+    calories: Number(caloriesInput),
+    servings: Number(servingsInput)
+  });
+}
+
+function remove(id) {
+  if (confirm('Delete food?')) {
+    store.removeFood(id);
+  }
+}
 </script>
 
 <template>
   <ul>
     <li v-for="item in store.foods" :key="item.id">
       {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
+      <button @click="edit(item)">Edit</button>
+      <button @click="remove(item.id)">Delete</button>
     </li>
   </ul>
 </template>

--- a/frontend/src/components/FoodList.vue
+++ b/frontend/src/components/FoodList.vue
@@ -1,19 +1,31 @@
 <script setup>
+import { ref, reactive } from 'vue';
+import Modal from './Modal.vue';
 import { useFoodStore } from '../store/foods';
 const store = useFoodStore();
 
-function edit(item) {
-  const name = prompt('Name', item.name);
-  if (name === null) return;
-  const caloriesInput = prompt('Calories', item.calories);
-  if (caloriesInput === null) return;
-  const servingsInput = prompt('Servings', item.servings);
-  if (servingsInput === null) return;
-  store.updateFood(item.id, {
-    name,
-    calories: Number(caloriesInput),
-    servings: Number(servingsInput)
+const editing = ref(null);
+const form = reactive({ name: '', calories: 0, servings: 1 });
+
+function startEdit(item) {
+  editing.value = item;
+  form.name = item.name;
+  form.calories = item.calories;
+  form.servings = item.servings;
+}
+
+function saveEdit() {
+  if (!editing.value) return;
+  store.updateFood(editing.value.id, {
+    name: form.name,
+    calories: Number(form.calories),
+    servings: Number(form.servings)
   });
+  editing.value = null;
+}
+
+function cancelEdit() {
+  editing.value = null;
 }
 
 function remove(id) {
@@ -24,13 +36,25 @@ function remove(id) {
 </script>
 
 <template>
+  <Modal v-if="editing" @close="cancelEdit">
+    <form @submit.prevent="saveEdit">
+      <h3>Edit Food</h3>
+      <input v-model="form.name" placeholder="Name" />
+      <input type="number" v-model.number="form.calories" placeholder="Calories" />
+      <input type="number" v-model.number="form.servings" placeholder="Servings" />
+      <div class="actions">
+        <button type="submit">Save</button>
+        <button type="button" @click="cancelEdit">Cancel</button>
+      </div>
+    </form>
+  </Modal>
   <ul>
     <li v-for="item in store.foods" :key="item.id" class="list-item">
       <span>
         {{ item.name }} ({{ item.calories }} cal, {{ item.servings }} serving{{ item.servings > 1 ? 's' : '' }})
       </span>
       <span class="actions">
-        <button @click="edit(item)">Edit</button>
+        <button @click="startEdit(item)">Edit</button>
         <button @click="remove(item.id)">Delete</button>
       </span>
     </li>

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -29,5 +29,7 @@ function goToRegister() {
     <input v-model="password" type="password" placeholder="Password" />
     <button type="submit">Login</button>
   </form>
-  <button type="button" @click="goToRegister">Register</button>
+  <div class="auth-link">
+    <button type="button" @click="goToRegister">Register</button>
+  </div>
 </template>

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -17,6 +17,10 @@ async function login() {
   } catch (e) {}
   router.push('/dashboard');
 }
+
+function goToRegister() {
+  router.push('/register');
+}
 </script>
 
 <template>
@@ -25,5 +29,5 @@ async function login() {
     <input v-model="password" type="password" placeholder="Password" />
     <button type="submit">Login</button>
   </form>
-  <router-link to="/register">Register</router-link>
+  <button type="button" @click="goToRegister">Register</button>
 </template>

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="modal-overlay" @click.self="$emit('close')">
+    <div class="modal">
+      <slot></slot>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -37,4 +37,7 @@ async function register() {
     </select>
     <button type="submit">Register</button>
   </form>
+  <div class="auth-note">
+    Are you already a member? Click here to <router-link to="/login">login</router-link>?
+  </div>
 </template>

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -1,18 +1,22 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import api from '../api';
 const username = ref('');
 const password = ref('');
 const height = ref('');
 const isMale = ref(1);
+const units = ref('scientific');
 const router = useRouter();
+const heightLabel = computed(() => (units.value === 'imperial' ? 'inches' : 'cm'));
 async function register() {
+  const heightIn = units.value === 'imperial' ? height.value : height.value / 2.54;
   await api.post('/auth/register', {
     username: username.value,
     password: password.value,
-    height_in: height.value,
-    is_male: isMale.value
+    height_in: heightIn,
+    is_male: isMale.value,
+    units: units.value
   });
   router.push('/login');
 }
@@ -22,7 +26,11 @@ async function register() {
   <form @submit.prevent="register">
     <input v-model="username" placeholder="Username" />
     <input v-model="password" type="password" placeholder="Password" />
-    <input v-model.number="height" type="number" placeholder="Height (inches)" />
+    <select v-model="units">
+      <option value="imperial">Imperial</option>
+      <option value="scientific">Scientific</option>
+    </select>
+    <input v-model.number="height" type="number" :placeholder="`Height (${heightLabel})`" />
     <select v-model.number="isMale">
       <option :value="1">Male</option>
       <option :value="0">Female</option>

--- a/frontend/src/components/WeightChart.vue
+++ b/frontend/src/components/WeightChart.vue
@@ -1,0 +1,34 @@
+<script setup>
+import { computed } from 'vue';
+import { useWeightStore } from '../store/weights';
+import { useUserStore } from '../store/user';
+
+const weightStore = useWeightStore();
+const userStore = useUserStore();
+const width = 400;
+const height = 200;
+
+const points = computed(() => {
+  const data = [...weightStore.weights].reverse();
+  if (!data.length) return '';
+  const values = data.map(w => (userStore.info?.units === 'imperial' ? w.weight * 2.20462 : w.weight));
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  return values
+    .map((v, i) => {
+      const x = (i / (values.length - 1 || 1)) * width;
+      const y = height - ((v - min) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+});
+</script>
+
+<template>
+  <div v-if="weightStore.weights.length">
+    <svg :width="width" :height="height">
+      <polyline :points="points" fill="none" stroke="blue" stroke-width="2" />
+    </svg>
+  </div>
+</template>

--- a/frontend/src/components/WeightForm.vue
+++ b/frontend/src/components/WeightForm.vue
@@ -1,11 +1,15 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import api from '../api';
+import { useUserStore } from '../store/user';
 const weight = ref('');
 const note = ref('');
 const emit = defineEmits(['saved']);
+const userStore = useUserStore();
+const unitLabel = computed(() => (userStore.info?.units === 'imperial' ? 'lbs' : 'kg'));
 async function submit() {
-  await api.post('/weights', { weight: weight.value, note: note.value });
+  const w = userStore.info?.units === 'imperial' ? weight.value / 2.20462 : weight.value;
+  await api.post('/weights', { weight: w, note: note.value });
   weight.value = '';
   note.value = '';
   emit('saved');
@@ -14,7 +18,7 @@ async function submit() {
 
 <template>
   <form @submit.prevent="submit">
-    <input v-model="weight" type="number" step="0.1" placeholder="Weight" />
+    <input v-model="weight" type="number" step="0.1" :placeholder="`Weight (${unitLabel})`" />
     <input v-model="note" placeholder="Note" />
     <button type="submit">Add</button>
   </form>

--- a/frontend/src/components/WeightList.vue
+++ b/frontend/src/components/WeightList.vue
@@ -13,6 +13,15 @@ const unitLabel = computed(() => (userStore.info?.units === 'imperial' ? 'lbs' :
 const displayWeight = w =>
   userStore.info?.units === 'imperial' ? (w * 2.20462).toFixed(1) : w;
 
+function arrowFor(index) {
+  const prev = store.weights[index + 1];
+  if (!prev) return '';
+  const diff = store.weights[index].weight - prev.weight;
+  if (diff > 0) return '↑';
+  if (diff < 0) return '↓';
+  return '→';
+}
+
 function edit(entry) {
   const input = prompt('Weight', displayWeight(entry.weight));
   if (input == null) return;
@@ -30,10 +39,15 @@ function remove(id) {
 
 <template>
   <ul>
-    <li v-for="entry in store.weights" :key="entry.id">
-      {{ formatDate(entry.entry_date) }} - {{ displayWeight(entry.weight) }} {{ unitLabel }}
-      <button @click="edit(entry)">Edit</button>
-      <button @click="remove(entry.id)">Delete</button>
+    <li v-for="(entry, index) in store.weights" :key="entry.id" class="list-item">
+      <span>
+        {{ formatDate(entry.entry_date) }} - {{ displayWeight(entry.weight) }} {{ unitLabel }}
+        <span v-if="arrowFor(index)" class="trend">{{ arrowFor(index) }}</span>
+      </span>
+      <span class="actions">
+        <button @click="edit(entry)">Edit</button>
+        <button @click="remove(entry.id)">Delete</button>
+      </span>
     </li>
   </ul>
 </template>

--- a/frontend/src/components/WeightList.vue
+++ b/frontend/src/components/WeightList.vue
@@ -1,15 +1,23 @@
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, computed } from 'vue';
 import { useWeightStore } from '../store/weights';
+import { useUserStore } from '../store/user';
 const store = useWeightStore();
-onMounted(() => store.fetchWeights());
+const userStore = useUserStore();
+onMounted(() => {
+  store.fetchWeights();
+  if (!userStore.info) userStore.fetch();
+});
 const formatDate = d => new Date(d).toLocaleDateString();
+const unitLabel = computed(() => (userStore.info?.units === 'imperial' ? 'lbs' : 'kg'));
+const displayWeight = w =>
+  userStore.info?.units === 'imperial' ? (w * 2.20462).toFixed(1) : w;
 </script>
 
 <template>
   <ul>
     <li v-for="entry in store.weights" :key="entry.id">
-      {{ formatDate(entry.entry_date) }} - {{ entry.weight }} kg
+      {{ formatDate(entry.entry_date) }} - {{ displayWeight(entry.weight) }} {{ unitLabel }}
     </li>
   </ul>
 </template>

--- a/frontend/src/components/WeightList.vue
+++ b/frontend/src/components/WeightList.vue
@@ -12,12 +12,28 @@ const formatDate = d => new Date(d).toLocaleDateString();
 const unitLabel = computed(() => (userStore.info?.units === 'imperial' ? 'lbs' : 'kg'));
 const displayWeight = w =>
   userStore.info?.units === 'imperial' ? (w * 2.20462).toFixed(1) : w;
+
+function edit(entry) {
+  const input = prompt('Weight', displayWeight(entry.weight));
+  if (input == null) return;
+  const w =
+    userStore.info?.units === 'imperial' ? parseFloat(input) / 2.20462 : Number(input);
+  store.updateWeight(entry.id, w);
+}
+
+function remove(id) {
+  if (confirm('Delete entry?')) {
+    store.removeWeight(id);
+  }
+}
 </script>
 
 <template>
   <ul>
     <li v-for="entry in store.weights" :key="entry.id">
       {{ formatDate(entry.entry_date) }} - {{ displayWeight(entry.weight) }} {{ unitLabel }}
+      <button @click="edit(entry)">Edit</button>
+      <button @click="remove(entry.id)">Delete</button>
     </li>
   </ul>
 </template>

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -1,6 +1,7 @@
 <script setup>
 import WeightForm from '../components/WeightForm.vue';
 import WeightList from '../components/WeightList.vue';
+import WeightChart from '../components/WeightChart.vue';
 import { useWeightStore } from '../store/weights';
 const store = useWeightStore();
 function refresh() {
@@ -11,6 +12,7 @@ function refresh() {
 <template>
   <div>
     <WeightForm @saved="refresh" />
+    <WeightChart />
     <WeightList />
   </div>
 </template>

--- a/frontend/src/pages/Settings.vue
+++ b/frontend/src/pages/Settings.vue
@@ -57,7 +57,7 @@ async function save() {
       </label>
       <label>
         Height ({{ form.units === 'imperial' ? 'in' : 'cm' }}):
-        <input type="number" v-model.number="form.height" />
+        <input type="number" step="0.1" v-model.number="form.height" />
       </label>
       <label>
         Gender:

--- a/frontend/src/store/foods.js
+++ b/frontend/src/store/foods.js
@@ -2,13 +2,22 @@ import { defineStore } from 'pinia';
 import api from '../api';
 
 export const useFoodStore = defineStore('foods', {
-  state: () => ({ foods: [], totalCalories: 0, remainingCalories: 0 }),
+  state: () => ({ foods: [], totalCalories: 0, remainingCalories: 0, currentDate: null }),
   actions: {
     async fetchFoods(date) {
       const res = await api.get('/foods', { params: { date } });
       this.foods = res.data.foods;
       this.totalCalories = res.data.totalCalories;
       this.remainingCalories = res.data.remainingCalories;
+      this.currentDate = date;
+    },
+    async updateFood(id, updates) {
+      await api.put(`/foods/${id}`, updates);
+      await this.fetchFoods(this.currentDate);
+    },
+    async removeFood(id) {
+      await api.delete(`/foods/${id}`);
+      await this.fetchFoods(this.currentDate);
     }
   }
 });

--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia';
+import api from '../api';
+
+export const useUserStore = defineStore('user', {
+  state: () => ({ info: null }),
+  actions: {
+    async fetch() {
+      const res = await api.get('/user');
+      this.info = res.data;
+    },
+    setUnits(units) {
+      if (this.info) {
+        this.info.units = units;
+      } else {
+        this.info = { units };
+      }
+    }
+  }
+});

--- a/frontend/src/store/weights.js
+++ b/frontend/src/store/weights.js
@@ -7,6 +7,14 @@ export const useWeightStore = defineStore('weights', {
     async fetchWeights() {
       const res = await api.get('/weights');
       this.weights = res.data;
+    },
+    async updateWeight(id, weight) {
+      await api.put(`/weights/${id}`, { weight });
+      await this.fetchWeights();
+    },
+    async removeWeight(id) {
+      await api.delete(`/weights/${id}`);
+      await this.fetchWeights();
     }
   }
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -70,6 +70,14 @@ input {
   color: var(--text-color);
 }
 
+select {
+  padding: 8px;
+  margin-bottom: 10px;
+  border: 1px solid var(--input-border);
+  background-color: var(--input-bg);
+  color: var(--text-color);
+}
+
 button {
   background-color: var(--button-bg);
   color: var(--button-color);
@@ -88,6 +96,20 @@ li {
   margin-bottom: 5px;
   padding: 5px;
   border: 1px solid var(--input-border);
+}
+
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.actions button {
+  margin-left: 5px;
+}
+
+.trend {
+  margin-left: 5px;
 }
 
 .container {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -141,3 +141,18 @@ li {
   display: flex;
   flex-direction: column;
 }
+
+.auth-link {
+  max-width: 400px;
+  margin: 10px auto 0;
+  text-align: right;
+}
+
+.auth-note {
+  max-width: 400px;
+  margin: 10px auto 0;
+}
+
+.auth-note a {
+  color: var(--primary-color);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -117,3 +117,27 @@ li {
   margin: 20px auto;
   padding: 0 15px;
 }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal {
+  background-color: var(--input-bg);
+  border: 1px solid var(--input-border);
+  padding: 20px;
+}
+
+.modal form {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Summary
- allow users to choose imperial or scientific units for measurements
- convert weights and height on the client based on unit preference
- persist unit preference in database and user APIs

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1de8d3308326ae1871244584c850